### PR TITLE
Update JqueryExtension.php

### DIFF
--- a/Twig/JqueryExtension.php
+++ b/Twig/JqueryExtension.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @package Evheniy\JqueryBundle\Twig
  */
-class JqueryExtension extends \Twig_Extension
+class JqueryExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     /**
      * @var \Symfony\Component\DependencyInjection\ContainerInterface


### PR DESCRIPTION
This class needs to implement \Twig_Extension_GlobalsInterface because of this warning message:

> Defining the getGlobals() method in an extension is deprecated without explicitly implementing Twig_Extension_GlobalsInterface.
